### PR TITLE
Allows us to upload to the pretty Azkaban URL

### DIFF
--- a/azkaban.py
+++ b/azkaban.py
@@ -310,7 +310,8 @@ class Project(object):
           files={
             'file': ('file.zip', open(path, 'rb'), 'application/zip'),
           },
-          verify=False
+          auth=(self.ldap_username, self.ldap_password),
+          verify=True
         )
       except ConnectionError:
         raise AzkabanError('unable to connect to azkaban server')
@@ -422,15 +423,18 @@ class Project(object):
     if not session_id or post(
       '%s/manager' % (url, ),
       {'session.id': session_id},
-      verify=False
+      verify=True
     ).text:
+      self.ldap_username = getuser()
+      self.ldap_password = getpass('ldap pass for %s: ' % (self.ldap_username, ))
       user = user or getuser()
       password = password or getpass('azkaban password for %s: ' % (user, ))
       try:
         req = post(
           url,
           data={'action': 'login', 'username': user, 'password': password},
-          verify=False,
+          auth=(self.ldap_username, self.ldap_password),
+          verify=True,
         )
       except ConnectionError:
         raise AzkabanError('unable to connect to azkaban server')


### PR DESCRIPTION
azkabanrc can now do the following:
[production]
url = https://azkaban.production.analytics.knewton.net/
user = isaak
session_id =

[staging]
url = https://azkaban.staging.analytics.knewton.net/
user = isaak
session_id =

Life is better.

Assumptions:
Your login for your local machine == your ldap username.
If this is not the case, in the future we'll have to have an ldap_user field in the azkabanrc.